### PR TITLE
Pc fix workflows 02 and 04

### DIFF
--- a/.github/workflows/02-gh-pages-rebuild-part-1-backend.yml
+++ b/.github/workflows/02-gh-pages-rebuild-part-1-backend.yml
@@ -271,7 +271,6 @@ jobs:
       id: download-artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
         branch: ${{ env.branch_name }}
         name: pitest-${{ matrix.value.number }}-history.bin

--- a/.github/workflows/04-gh-pages-redeploy-part-2-backend.yml
+++ b/.github/workflows/04-gh-pages-redeploy-part-2-backend.yml
@@ -106,7 +106,6 @@ jobs:
     - name: a-javadoc Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
         name: javadoc
         path: ${{env.javadoc_dest }}
@@ -129,7 +128,6 @@ jobs:
     - name: c-jacoco Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
         name: jacoco
         path: ${{ env.jacoco_dest }}
@@ -150,7 +148,6 @@ jobs:
     - name:  d-pitest Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
         name: pitest
         path: ${{ env.pitest_dest }}
@@ -188,7 +185,6 @@ jobs:
     - name: a-javadoc Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
         name: prs-${{ matrix.value.number }}-javadoc
         path: ${{ env.javadoc_dest }}
@@ -210,7 +206,6 @@ jobs:
     - name:  c-jacoco Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
         name: prs-${{ matrix.value.number }}-jacoco
         path: ${{ env.jacoco_dest }}
@@ -231,7 +226,6 @@ jobs:
     - name: d-pitest Download artifact
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
-        workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
         name: prs-${{ matrix.value.number }}-pitest
         path: ${{ env.pitest_dest }}


### PR DESCRIPTION
In this PR, we fix some problems with workflows 02 and 04 that were causing them to not work properly.

In particular, we remove the specification of the workflow when uploading/downloading artifacts.  This appears to be unnecessary and error prone.